### PR TITLE
Add full lecture title to html title attribute

### DIFF
--- a/src/components/InstructorAttendanceHistory.vue
+++ b/src/components/InstructorAttendanceHistory.vue
@@ -17,7 +17,7 @@
           <div class="month-area">{{ STATIC_MONTHS[month] }} {{year}}</div>
           <div class="event-pills-area">
             <router-link v-for="i in timeline[year][month]" :key="lectures[i]._id" :to="{name: 'lecture_info', params: { lecture_id: lectures[i]._id }}" tabindex="-1">
-              <div :class="'inline-block instructor-attendance-history-pill ' + getHTMLClassByAttendance(lectures[i].percentage == undefined ? 0 : lectures[i].percentage)" tabindex="0" :aria-label="'Lecture Info - '+lectures[i].title">
+              <div :class="'inline-block instructor-attendance-history-pill ' + getHTMLClassByAttendance(lectures[i].percentage == undefined ? 0 : lectures[i].percentage)" tabindex="0" :title="lectures[i].title" :aria-label="'Lecture Info - '+lectures[i].title">
                 <div class="inline-block date-area">
                   <div class="day-of-week">{{ getDayOfWeek(lectures[i]) }}</div>
                   <div class="day-of-month">{{ getDayOfMonth(lectures[i]) }}</div>

--- a/src/components/StudentAttendanceHistory.vue
+++ b/src/components/StudentAttendanceHistory.vue
@@ -17,7 +17,7 @@
           <div class="month-area">{{ STATIC_MONTHS[month] }} {{year}}</div>
           <div class="event-pills-area">
             <router-link v-for="i in timeline[year][month]" :key="lectures[i]._id" :to="{name: 'lecture_info', params: { lecture_id: lectures[i]._id }}" tabindex="-1">
-              <div :class="'inline-block instructor-attendance-history-pill ' + getHTMLClassByAttendance(lectures[i].percentage == undefined ? 0 : lectures[i].percentage)" tabindex="0" :aria-label="'Lecture Info - '+lectures[i].title">
+              <div :class="'inline-block instructor-attendance-history-pill ' + getHTMLClassByAttendance(lectures[i].percentage == undefined ? 0 : lectures[i].percentage)" tabindex="0" :title="lectures[i].title" :aria-label="'Lecture Info - '+lectures[i].title">
                 <div class="inline-block date-area">
                   <div class="day-of-week">{{ getDayOfWeek(lectures[i]) }}</div>
                   <div class="day-of-month">{{ getDayOfMonth(lectures[i]) }}</div>


### PR DESCRIPTION
When you are looking at a lecture the title can be cut off if it is too long. 
![image](https://user-images.githubusercontent.com/18558130/87187020-7d4b1680-c2ba-11ea-818c-e39bb90705f8.png)

This pr adds a title attribute which allows the user to view the full title when they hover over the element
![image](https://user-images.githubusercontent.com/18558130/87187139-ae2b4b80-c2ba-11ea-968a-10fdba936e1e.png)
