### PR TITLE
User in request

### DIFF
--- a/server/Auth/Auth.route.js
+++ b/server/Auth/Auth.route.js
@@ -89,10 +89,10 @@ authRoutes.route('/login').post(function (req, res) {
         res.status(404).json({ error: 'Invalid Login Credentials. Please try again' })
       }
       else {
-        console.log(current_user)
         bcrypt.compare(user.password, current_user.password, function(err, result) {
           if(result == true){
             const token = jwt.sign({ current_user }, process.env.AUTH_KEY)
+            console.log("<SUCCESS> Login for user with User ID:",current_user.user_id)
             res.json({token, current_user})
           } else {
             res.status(404).json({ error: 'Invalid Login Credentials. Please try again' })

--- a/server/Lecture/Lecture.route.js
+++ b/server/Lecture/Lecture.route.js
@@ -101,7 +101,7 @@ lectureRoutes.post('/add_playback_video/:lecture_id', upload.single('video'),fun
 lectureRoutes.route('/update_to_playback/:lecture_id').post(function (req, res) {
 	let lecture_id = req.params.lecture_id
 	let lecture = req.body.lecture
-	console.log("Received lecture",lecture)
+	
 	Lecture.findByIdAndUpdate(lecture_id,
 		{
 			playback_submission_start_time: lecture.playback_submission_start_time,

--- a/server/server.js
+++ b/server/server.js
@@ -30,6 +30,7 @@ function start() {
       const bearer = bearerHeader.split(' ')
       const bearerToken = bearer[1]
       req.token = bearerToken
+      req.user = JSON.parse(req.headers['user'])
       jwt.verify(req.token, process.env.AUTH_KEY, err => {
         if(err)
           res.sendStatus(401).send("Unauthorized access")

--- a/src/vuex/store.js
+++ b/src/vuex/store.js
@@ -20,6 +20,7 @@ export default new Vuex.Store({
         axios.defaults.headers.common['Authorization'] = `Bearer ${
           userData.token
         }`
+        axios.defaults.headers.common['User'] = JSON.stringify(userData.current_user)
       }
     },
     CLEAR_USER_DATA() {


### PR DESCRIPTION
adds the cached user object to all axios requests. in any route, after JWT authorization, the attached user object can be found with 'user' as the key under whatever the request is named after.

This will allow for easily checking if an API request should be performed for specific users (whether a user is an instructor or not, whether the user is the instructor to a specified course, etc.) without the need of manually looking up a user in the database.